### PR TITLE
Add chmod ssh config to initial setup

### DIFF
--- a/topics/terminal-usage/initial-setup/index.md
+++ b/topics/terminal-usage/initial-setup/index.md
@@ -105,7 +105,8 @@ that (you don't need to understand this command yet--we'll cover it later in the
 semester). Copy and paste the command into your terminal and hit enter.
 
 {% highlight bash %}
-mkdir -p ~/.ssh; touch ~/.ssh/config; nano ~/.ssh/config
+mkdir ~/.ssh && touch ~/.ssh/config && chmod 600 ~/.ssh/config && nano
+~/.ssh/config
 {% endhighlight %}
 
 Add the following (replacing `ANDREWID` with your Andrew ID) to this file, save


### PR DESCRIPTION
To address https://piazza.com/class/j6sc56c5l244t7?cid=10

I didn't make it win10 specific since it should be harmless on other systems too.

Also removed -p from mkdir since it's unneeded here (at worst, dangerous if ~ strangely didn't exist), and changed ; to && for safety.